### PR TITLE
Upstream 2.22.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,7 @@
 task:
   only_if: $CIRRUS_TAG == ''
   env:
-    matrix:
-      - RELEASEVER: 6
-      - RELEASEVER: 7
+    RELEASEVER: 7
   name: el$RELEASEVER
   container:
     image: centos:$RELEASEVER

--- a/git222.spec
+++ b/git222.spec
@@ -84,7 +84,7 @@
 %endif
 
 Name:           git222
-Version:        2.22.4
+Version:        2.22.5
 Release:        1%{?dist}
 Summary:        Fast Version Control System
 License:        GPLv2
@@ -991,6 +991,10 @@ rmdir --ignore-fail-on-non-empty "$testdir"
 %{?with_docs:%{_pkgdocdir}/git-svn.html}
 
 %changelog
+* Wed Mar 10 2021 Jeff Sheltren <jeff@tag1consulting.com> - 2.22.5-1
+- Latest upstream
+- Fixes CVE-2021-21300
+
 * Thu Jul 23 2020 Chun-Chi Hung <b10102229@gmail.com> - 2.22.4-1
 - Latest upstream
 - Includes fix for CVE-2020-11008


### PR DESCRIPTION
This bumps version to 2.22.5 to fix CVE-2021-21300 and disables builds on EL6 which is now EOL.